### PR TITLE
Extend default options rather than assign with provided options

### DIFF
--- a/lib/less.js
+++ b/lib/less.js
@@ -18,7 +18,7 @@ var fs = require('fs');
 var url = require('url');
 var path = require('path');
 var async = require('async');
-var assign = require('object-assign');
+var extend = require('extend');
 var less = require('less-openui5');
 
 
@@ -51,7 +51,7 @@ module.exports = function(options) {
 				return;
 			}
 
-			var lessOptions = assign({
+			var lessOptions = extend(true, {
 				parser: {
 					filename: lessInfo.path
 				}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "extend": "^3.0.0",
     "glob": "^5.0.5",
     "http-proxy": "^1.10.1",
-    "less-openui5": "^0.1.2",
-    "object-assign": "^4.0.1"
+    "less-openui5": "^0.1.2"
   },
   "devDependencies": {
     "connect": "^3.3.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "async": "^1.4.2",
+    "extend": "^3.0.0",
     "glob": "^5.0.5",
     "http-proxy": "^1.10.1",
     "less-openui5": "^0.1.2",


### PR DESCRIPTION
[FIX] less: less default options should rather be extended

the less default options have been overruled by the provided consumer options which results in exceptions due to missing default options

Now the default options are extended with the provided consumer options