### PR TITLE
Travis CI: Test Node.js 4, 6 and 8 with npm v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,29 @@
+# Use container-based infrastructure
 sudo: false
+
 language: node_js
 node_js:
-  - "7"
+  - "8"
   - "6"
-  - "5"
   - "4"
-  - "0.12"
+
+matrix:
+  include:
+    # Test latest Node.js version also with a fresh install (no package-lock.json)
+    - node_js: 8
+      env: FRESH_INSTALL=true
+
+cache:
+  directories:
+    # Cache local npm cache files for faster install
+    - $HOME/.npm
+
+before_install:
+  # Always use npm@5
+  - npm install --global npm@^5
+  # Remove package-lock.json to force a fresh install (updated dependencies)
+  - if [[ ${FRESH_INSTALL} == "true" ]]; then rm package-lock.json; fi
+
+install:
+  # Prefer online to install latest dependencies - othersise make use of the local cache
+  - if [[ ${FRESH_INSTALL} == "true" ]]; then npm install --prefer-online; else npm install --prefer-offline; fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1660 @@
+{
+  "name": "connect-openui5",
+  "version": "0.7.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "optional": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "optional": true
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "optional": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "optional": true
+    },
+    "atob": {
+      "version": "1.1.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M="
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "optional": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "optional": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "optional": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/circular-json/-/circular-json-0.3.1.tgz",
+      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "dev": true
+    },
+    "clean-css": {
+      "version": "2.0.8",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/clean-css/-/clean-css-2.0.8.tgz",
+      "integrity": "sha1-6TfN/cxXgaAIF67EB56Fs+wVeiA=",
+      "optional": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true
+    },
+    "cli-width": {
+      "version": "1.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/cli-width/-/cli-width-1.1.1.tgz",
+      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "optional": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+    },
+    "commander": {
+      "version": "2.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/commander/-/commander-2.0.0.tgz",
+      "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg=",
+      "optional": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true
+    },
+    "connect": {
+      "version": "3.6.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/connect/-/connect-3.6.2.tgz",
+      "integrity": "sha1-aU6NIGgb/kkCgsiriGvpjwn0L+c=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "optional": true
+    },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw="
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.7",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/debug/-/debug-2.6.7.tgz",
+      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+      "dev": true
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/depd/-/depd-1.1.0.tgz",
+      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "0.7.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/doctrine/-/doctrine-0.7.2.tgz",
+      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+      "dev": true,
+      "dependencies": {
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "dev": true
+    },
+    "es5-ext": {
+      "version": "0.10.23",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/es5-ext/-/es5-ext-0.10.23.tgz",
+      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+      "dev": true
+    },
+    "es6-iterator": {
+      "version": "2.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "dev": true
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "1.10.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/eslint/-/eslint-1.10.3.tgz",
+      "integrity": "sha1-+xmpGxPBWAgrvKKUsX2Xm8g1Ogo=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true
+        }
+      }
+    },
+    "espree": {
+      "version": "2.2.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/espree/-/espree-2.2.5.tgz",
+      "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "estraverse-fb": {
+      "version": "1.3.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
+      "integrity": "sha1-Fg51qA5gWwjOiUvM4v4+Qpq/kr8=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/etag/-/etag-1.8.0.tgz",
+      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+    },
+    "fast-levenshtein": {
+      "version": "1.0.7",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true
+    },
+    "finalhandler": {
+      "version": "1.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/finalhandler/-/finalhandler-1.0.3.tgz",
+      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
+      "dev": true
+    },
+    "flat-cache": {
+      "version": "1.2.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/flat-cache/-/flat-cache-1.2.2.tgz",
+      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "optional": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "optional": true
+    },
+    "fresh": {
+      "version": "0.5.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/fresh/-/fresh-0.5.0.tgz",
+      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
+        }
+      }
+    },
+    "glob": {
+      "version": "6.0.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI="
+    },
+    "globals": {
+      "version": "8.18.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/globals/-/globals-8.18.0.tgz",
+      "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.10",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "dev": true,
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true
+        }
+      }
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "optional": true
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "optional": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "optional": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "http-errors": {
+      "version": "1.6.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/http-errors/-/http-errors-1.6.1.tgz",
+      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.16.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/http-proxy/-/http-proxy-1.16.2.tgz",
+      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I="
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "optional": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inquirer": {
+      "version": "0.11.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/inquirer/-/inquirer-0.11.4.tgz",
+      "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.16.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "optional": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "optional": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "3.4.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/js-yaml/-/js-yaml-3.4.5.tgz",
+      "integrity": "sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=",
+      "dev": true,
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "optional": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "optional": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "less": {
+      "version": "1.6.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/less/-/less-1.6.3.tgz",
+      "integrity": "sha1-cc6J7DC3dLNWfyVMZ5WPLywZO94="
+    },
+    "less-openui5": {
+      "version": "0.3.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/less-openui5/-/less-openui5-0.3.1.tgz",
+      "integrity": "sha1-cxuYxgt5EpwhN6hRMJ0xaFk5a+c="
+    },
+    "levn": {
+      "version": "0.2.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/levn/-/levn-0.2.5.tgz",
+      "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+      "dev": true
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "dev": true
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "dev": true
+    },
+    "lodash._arraymap": {
+      "version": "3.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "dev": true
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basedifference": {
+      "version": "3.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+      "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+      "dev": true
+    },
+    "lodash._baseflatten": {
+      "version": "3.1.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+      "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+      "dev": true
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "dev": true
+    },
+    "lodash._baseindexof": {
+      "version": "3.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+      "dev": true
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
+    },
+    "lodash._cacheindexof": {
+      "version": "3.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+      "dev": true
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "dev": true
+    },
+    "lodash._createcache": {
+      "version": "3.1.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._pickbyarray": {
+      "version": "3.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+      "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
+      "dev": true
+    },
+    "lodash._pickbycallback": {
+      "version": "3.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+      "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "dev": true
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "3.3.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+      "dev": true
+    },
+    "lodash.omit": {
+      "version": "3.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.omit/-/lodash.omit-3.1.0.tgz",
+      "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
+      "dev": true
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.toplainobject": {
+      "version": "3.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+      "optional": true
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+      "optional": true
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/supports-color/-/supports-color-1.2.0.tgz",
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "optional": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true
+    },
+    "optionator": {
+      "version": "0.6.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/optionator/-/optionator-0.6.0.tgz",
+      "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "parseurl": {
+      "version": "1.3.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/parseurl/-/parseurl-1.3.1.tgz",
+      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "optional": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "optional": true
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+      "optional": true
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/readable-stream/-/readable-stream-2.3.1.tgz",
+      "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
+      "dev": true
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.81.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "optional": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true
+        }
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "send": {
+      "version": "0.15.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/send/-/send-0.15.3.tgz",
+      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
+      "dev": true,
+      "dependencies": {
+        "mime": {
+          "version": "1.3.4",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mime/-/mime-1.3.4.tgz",
+          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.12.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/serve-static/-/serve-static-1.12.3.tgz",
+      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
+      "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.5.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/shelljs/-/shelljs-0.5.3.tgz",
+      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "optional": true
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y="
+    },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E="
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/string_decoder/-/string_decoder-1.0.2.tgz",
+      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
+        }
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "optional": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "optional": true
+    },
+    "tryit": {
+      "version": "1.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "optional": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "optional": true
+    },
+    "verror": {
+      "version": "1.3.6",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "optional": true
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true
+        }
+      }
+    },
+    "xml-escape": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/xml-escape/-/xml-escape-1.0.0.tgz",
+      "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "SAP SE",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">=4"
   },
   "dependencies": {
     "async": "^1.5.2",


### PR DESCRIPTION
- Dropping v0.12 as it's not supported anymore
- Adding test matrix for latest dependencies
  (without package-lock.json)