### PR TITLE
Adapt tests to current .eslintrc

### DIFF
--- a/test/mergeUrls_test.js
+++ b/test/mergeUrls_test.js
@@ -18,8 +18,8 @@
 var proxy = require('../').proxy;
 var assert = require('assert');
 
-function test(remote_location, pUrl, expected) {
-	var uri = proxy._createUri(pUrl, remote_location);
+function test(sRemoteLocation, pUrl, expected) {
+	var uri = proxy._createUri(pUrl, sRemoteLocation);
 	var url = proxy._buildRequestUrl(uri);
 	assert.equal(url, expected);
 }

--- a/test/proxy_ignore_remote_location_test.js
+++ b/test/proxy_ignore_remote_location_test.js
@@ -26,7 +26,7 @@ var proxy = require('../lib/proxy');
 delete require.cache[require.resolve('../lib/proxy')];
 
 describe('IGNORE remote location', function () {
-	it('should proxy from one server to the server and IGNORE remote location', function (done) {
+	it('should proxy from one server to the server and IGNORE remote location', function (fnDone) {
 		//check environment
 		assert.equal(proxy._env.remoteLocation,'http://localhost:8085');
 
@@ -54,6 +54,9 @@ describe('IGNORE remote location', function () {
 		oProxyApp.use(proxy());
 		var oProxyServer = http.createServer(oProxyApp);
 		oProxyServer.listen(9000);
+		oServerToBeProxied.on('close', function() {
+			oProxyServer.close();
+		});
 
 		//should still proxy to port 8080 and not to port 8085
 		http.get('http://localhost:9000/http/localhost:8080' + sExpectedPath, function (oResponse) {
@@ -66,15 +69,7 @@ describe('IGNORE remote location', function () {
 				assert.equal(sActualPath, sExpectedPath);
 				assert.equal(sActualResponse, sExpectedResponse);
 				assert.equal(iActualStatusCode, iExpectedStatusCode);
-
-				oProxyServer.on('close', function() {
-					done();
-				});
-
-				oServerToBeProxied.on('close', function() {
-					oProxyServer.close();
-				});
-
+				oProxyServer.on('close', fnDone);
 				oServerToBeProxied.close();
 			});
 		});

--- a/test/proxy_use_remote_location_test.js
+++ b/test/proxy_use_remote_location_test.js
@@ -26,7 +26,7 @@ var proxy = require('../lib/proxy');
 delete require.cache[require.resolve('../lib/proxy')];
 
 describe('USE remote location', function () {
-	it('should proxy from one server to the server and USE remote location', function (done) {
+	it('should proxy from one server to the server and USE remote location', function (fnDone) {
 		//check environment
 		assert.equal(proxy._env.remoteLocation,'http://localhost:8080');
 
@@ -54,6 +54,9 @@ describe('USE remote location', function () {
 		oProxyApp.use(proxy());
 		var oProxyServer = http.createServer(oProxyApp);
 		oProxyServer.listen(9000);
+		oServerToBeProxied.on('close', function() {
+			oProxyServer.close();
+		});
 
 		//should  proxy to port 8080
 		http.get('http://localhost:9000' + sExpectedPath, function (oResponse) {
@@ -66,15 +69,7 @@ describe('USE remote location', function () {
 				assert.equal(sActualPath, sExpectedPath);
 				assert.equal(sActualResponse, sExpectedResponse);
 				assert.equal(iActualStatusCode, iExpectedStatusCode);
-
-				oProxyServer.on('close', function() {
-					done();
-				});
-
-				oServerToBeProxied.on('close', function() {
-					oProxyServer.close();
-				});
-
+				oProxyServer.on('close', fnDone);
 				oServerToBeProxied.close();
 			});
 		});


### PR DESCRIPTION
Just downloaded it to explore a bit, and tests failed out of the box, so I fixed the eslint warnings first:

* Un-nesting the "done" callback was trivial. :-)
* Closing the proxy when its upstream server goes away seems sensible independent of whether the GET request succeeded.
* Hungarianized some var names.

What may be next:
* The "use" and "ignore" proxy tests look mostly the same; should I factor out the shared code in another PR?
* I needed to run `npm test` with `http_proxy= ` in front (to unset the env var) or it would fail with `Uncaught Error: listen EADDRINUSE :::8080`. Shall I make a PR that checks for this scenario and advises to unset the proxy config?
* Before I discovered the proxy reset requirement, I thought I had my own proxy on port 8080, because some of my machines do use that port. While debugging it, I found lots of hard-coded port numbers in the tests. Shall I replace them with variables, keeping the old ports as default but making it easy to override test ports by env vars? (e.g. `TEST_PORTS=4401,4402,4403 npm test`)