### PR TITLE
[FIX] Also strip 'secure' cookie flag at the end of the header.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -141,11 +141,11 @@ module.exports = function (options) {
 			// array == multiple cookies
 			if (Array.isArray(cookies)) {
 				for (var i = 0; i < cookies.length; i++) {
-					cookies[i] = cookies[i].replace('secure;', '');
+					cookies[i] = cookies[i].replace(';\s*secure\b', '');
 				}
 			} else if (typeof cookies === 'string' || cookies instanceof String) {
 				// single cookie
-				cookies = cookies.replace('secure;', '');
+				cookies = cookies.replace(';\s*secure\b', '');
 			}
 
 			if (cookies) {


### PR DESCRIPTION
Currently the 'secure' flag is not stripped if it appears at the end of the set-cookie header. This change will fix the issue.