### PR TITLE
[FIX] Properly remove the secure flag from cookies

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -141,11 +141,11 @@ module.exports = function (options) {
 			// array == multiple cookies
 			if (Array.isArray(cookies)) {
 				for (var i = 0; i < cookies.length; i++) {
-					cookies[i] = cookies[i].replace(';\s*secure\b', '');
+					cookies[i] = cookies[i].replace(/;\s*secure\b/, '');
 				}
 			} else if (typeof cookies === 'string' || cookies instanceof String) {
 				// single cookie
-				cookies = cookies.replace(';\s*secure\b', '');
+				cookies = cookies.replace(/;\s*secure\b/, '');
 			}
 
 			if (cookies) {


### PR DESCRIPTION
The current replace was not working due to regexp instruction being used as a string.